### PR TITLE
fix: Use pkg_resources to find the path for `questions.json`

### DIFF
--- a/src/the_well_maintained_test/cli.py
+++ b/src/the_well_maintained_test/cli.py
@@ -1,9 +1,9 @@
-import importlib.resources
 import json
-import pathlib
+from pathlib import Path
 from urllib.parse import urlparse
 
 import click
+import pkg_resources
 import requests
 from rich.console import Console
 from rich.padding import Padding
@@ -64,7 +64,7 @@ def auth(auth: str) -> None:  # pragma: no cover
     "Save authentication credentials to a JSON file"
     console.print("Create a GitHub personal user token and paste it here:")
     personal_token = Prompt.ask("Personal token")
-    if pathlib.Path(auth).exists():
+    if Path(auth).exists():
         auth_data = json.load(open(auth))
     else:
         auth_data = {}
@@ -96,7 +96,7 @@ def url(url: str, branch: str, progress: bool) -> None:  # pragma: no cover
     if url[-1] == "/":
         url = url.strip("/")
 
-    with importlib.resources.open_text("the_well_maintained_test.data", "questions.json") as file:
+    with open(Path(pkg_resources.resource_filename(__name__, str(Path("data").joinpath("questions.json"))))) as file:
         questions = json.load(file)
 
     parse_object = urlparse(url)
@@ -165,7 +165,7 @@ def url(url: str, branch: str, progress: bool) -> None:  # pragma: no cover
 )
 def questions(question: str) -> None:  # pragma: no cover
     "List of questions tested"
-    with importlib.resources.open_text("the_well_maintained_test.data", "questions.json") as file:
+    with open(Path(pkg_resources.resource_filename(__name__, str(Path("data").joinpath("questions.json"))))) as file:
         questions = json.load(file)
 
     if question != "all":


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Partially resolves Issue #15. c.f. https://github.com/ryancheley/the-well-maintained-test/issues/15#issuecomment-984079582 for full details.

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15

```pytb
(venv) root@2114cca7921b:~# the-well-maintained-test questions
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/importlib/resources.py", line 97, in open_binary
    return open(full_path, mode='rb')
FileNotFoundError: [Errno 2] No such file or directory: '/root/questions.json'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/venv/bin/the-well-maintained-test", line 8, in <module>
    sys.exit(cli())
  File "/venv/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/venv/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/venv/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/venv/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/venv/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/venv/lib/python3.9/site-packages/the_well_maintained_test/cli.py", line 168, in questions
    with importlib.resources.open_text("the_well_maintained_test.data", "questions.json") as file:
  File "/usr/local/lib/python3.9/importlib/resources.py", line 121, in open_text
    open_binary(package, resource), encoding=encoding, errors=errors)
  File "/usr/local/lib/python3.9/importlib/resources.py", line 111, in open_binary
    raise FileNotFoundError(message)
FileNotFoundError: 'questions.json' resource not found in 'the_well_maintained_test.data'
```

## What is the new behavior?

`questions.json` is findable upon installation.

```console
(the-well-maintained-test-dev) $ the-well-maintained-test questions
1. Is it described as “production ready”?
2. Is there sufficient documentation?
3. Is there a changelog?
4. Is someone responding to bug reports?
5. Are there sufficient tests?
6. Are the tests running with the latest <Language> version?
7. Are the tests running with the latest <Integration> version?
8. Is there a Continuous Integration (CI) configuration?
9. Is the CI passing?
10. Does it seem relatively well used?
11. Has there been a commit in the last year?
12. Has there been a release in the last year?
```