### PR TITLE
ci: Run CI on push, pull_request, schedule, and workflow_dispatch events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,14 @@
 name: Test
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+    - main
+  # Run daily at 1:23 UTC
+  schedule:
+  - cron:  '23 1 * * *'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Run the CI on:
* push events (this is already happening)
* pull requests that are targeting 'main' (like this one)
* As a daily CRON job that runs at 1:23 UTC to check for dependency changes
unrelated to source code changes
* On demand through workflow dispatch

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:


- [x] Other (please describe): CI

## What is the current behavior?

To only run on push events (so the CI isn't run on PRs at the moment)

## What is the new behavior?

Run the CI on PRs, a daily CRON job, and on demand.